### PR TITLE
fix order_product table

### DIFF
--- a/scripts/lesson7/create.product_order.table.xml
+++ b/scripts/lesson7/create.product_order.table.xml
@@ -17,7 +17,7 @@
                 <constraints nullable="false"/>
             </column>
             <column name="ORDER_ID" type="BIGINT">
-                <constraints unique="true"/>
+                <constraints nullable="false"/>
             </column>
         </createTable>
 


### PR DESCRIPTION
Артём, добрый вечер. В процессе выполнения 8 дз и создания заказов столкнулся с проблемой, что заказы не создавались: ругалось на нарушение ограничений уникальности. Посмотрел скрипты, увидел что в таблице order_product на поле order_id стоит значение unique, что по сути запрещает нам создавать заказы с несколькими продуктами. Поставил not null и все отработало корректно.